### PR TITLE
release pthread_mutexattr_t

### DIFF
--- a/common/Mutex.cc
+++ b/common/Mutex.cc
@@ -57,6 +57,7 @@ Mutex::Mutex(const char *n, bool r, bool ld,
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
     pthread_mutex_init(&_m, &attr);
+    pthread_mutexattr_destroy(&attr);
     if (g_lockdep)
       _register();
   }


### PR DESCRIPTION
I was using ceph-dokan in production. But it was using more and more memory util it crashed. 
So I use Dr.Memory to analyze memory leak for ceph-dokan then I found that the most memory leak is pthread_mutexattr_init. 
According to the pthread man page it seems that pthread_mutexattr_destroy should been invoked to release its memory. 
I add pthread_mutexattr_destroy and the memory cost seems stable when I use ceph-dokan. I am a Python developer and a newbie with these environment(Mingw, pthread, C++ ..etc). I am not sure  if this is a problem. 
