### PR TITLE
use closesocket to close socket

### DIFF
--- a/msg/simple/Pipe.cc
+++ b/msg/simple/Pipe.cc
@@ -879,8 +879,10 @@ int Pipe::connect()
   const md_config_t *conf = msgr->cct->_conf;
 
   // close old socket.  this is safe because we stopped the reader thread above.
-  if (sd >= 0)
+  if (sd >= 0) {
+    ::closesocket(sd);
     ::close(sd);
+  }
 
   // create socket?
   sd = ::socket(peer_addr.get_family(), SOCK_STREAM, 0);
@@ -1208,6 +1210,10 @@ int Pipe::connect()
 
  stop_locked:
   delete authorizer;
+  if (sd > 0) {
+    ::closesocket(sd);
+    ::close(sd);
+  }
   return -1;
 }
 

--- a/msg/simple/SimpleMessenger.cc
+++ b/msg/simple/SimpleMessenger.cc
@@ -248,8 +248,10 @@ void SimpleMessenger::reaper()
     p->join();
     lock.Lock();
 
-    if (p->sd >= 0)
+    if (p->sd >= 0) {
+      ::closesocket(p->sd);
       ::close(p->sd);
+    }
     ldout(cct,10) << "reaper reaped pipe " << p << " " << p->get_peer_addr() << dendl;
     p->put();
     ldout(cct,10) << "reaper deleted pipe " << p << dendl;


### PR DESCRIPTION
After running about 2 weeks, ceph-dokan is using about 20000 handles and the system can't create  socket connection any more. I use dr memory and find that these socket handles are leaked. So I try to use windows closesocket method to close socket instead of the default close method. And then handle leak problem seems to be resolved.
